### PR TITLE
Add 'zoom-box' to the viewer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -793,7 +793,7 @@ module = [
     "napari._app_model.context._layerlist_context",
     "napari.components.overlays.labels_polygon",
     "napari.plugins.io",
-    "napari.utils.colormaps.vendored._cm_listed"
+    "napari.utils.colormaps.vendored._cm_listed",
 ]
 disallow_untyped_calls = false
 

--- a/src/napari/_qt/_tests/test_qt_viewer.py
+++ b/src/napari/_qt/_tests/test_qt_viewer.py
@@ -1397,3 +1397,114 @@ def test_dask_cache(qt_viewer):
     mock_resize_dask_cache.assert_called_once_with(
         int(int(True) * initial_dask_cache * 1e9)
     )
+
+
+def test_viewer_drag_to_zoom(qt_viewer, qtbot):
+    """Test drag to zoom mouse binding."""
+    viewer = qt_viewer.viewer
+    canvas = qt_viewer.canvas
+
+    if os.getenv('CI'):
+        qt_viewer.show()
+
+    def zoom_callback(event):
+        """Mock zoom callback to check zoom box visibility."""
+        data_positions = event.value
+        assert len(data_positions) == 2, (
+            'Zoom event should release two positions'
+        )
+
+    viewer._zoom_box.events.zoom.connect(zoom_callback)
+
+    # Add an image layer
+    data = np.random.random((10, 20))
+    viewer.add_image(data)
+
+    assert viewer._zoom_box.visible is False, (
+        'Zoom box should be hidden initially'
+    )
+    # Simulate press to start zooming
+    canvas._scene_canvas.events.mouse_press(
+        pos=(0, 0), modifiers=('Alt',), button=0
+    )
+    qtbot.wait(10)
+    assert viewer._zoom_box.visible is True, (
+        'Zoom box should be visible after press'
+    )
+
+    # Simulate drag to zoom
+    canvas._scene_canvas.events.mouse_move(
+        pos=(100, 100),
+        modifiers=('Alt',),
+        button=0,
+        press_event=MouseEvent(
+            pos=(0, 0), modifiers=('Alt',), button=0, type='mouse_press'
+        ),
+    )
+    qtbot.wait(10)
+    assert viewer._zoom_box.visible is True, (
+        'Zoom box should remain visible during drag'
+    )
+    assert viewer._zoom_box.canvas_positions == ((0, 0), (100, 100)), (
+        'Zoom box canvas positions should match the drag coordinates'
+    )
+
+    # Simulate release to finish zooming
+    canvas._scene_canvas.events.mouse_release(
+        pos=(100, 100), modifiers=('Alt',), button=0
+    )
+    qtbot.wait(10)
+    assert viewer._zoom_box.visible is False, (
+        'Zoom box should be hidden after release'
+    )
+
+
+def test_viewer_drag_to_zoom_with_cancel(qt_viewer, qtbot):
+    """Test drag to zoom mouse binding."""
+    viewer = qt_viewer.viewer
+    canvas = qt_viewer.canvas
+
+    if os.getenv('CI'):
+        qt_viewer.show()
+
+    def zoom_callback(event):
+        """Mock zoom callback to check zoom box visibility."""
+        data_positions = event.value
+        assert len(data_positions) == 2, (
+            'Zoom event should release two positions'
+        )
+
+    viewer._zoom_box.events.zoom.connect(zoom_callback)
+
+    # Add an image layer
+    data = np.random.random((10, 20))
+    viewer.add_image(data)
+
+    assert viewer._zoom_box.visible is False, (
+        'Zoom box should be hidden initially'
+    )
+    # Simulate press to start zooming
+    canvas._scene_canvas.events.mouse_press(
+        pos=(0, 0), modifiers=('Alt',), button=0
+    )
+    qtbot.wait(10)
+    assert viewer._zoom_box.visible is True, (
+        'Zoom box should be visible after press'
+    )
+
+    # Simulate drag to zoom BUT remove modifiers to cancel
+    canvas._scene_canvas.events.mouse_move(
+        pos=(100, 100),
+        modifiers=(),
+        button=0,
+        press_event=MouseEvent(
+            pos=(0, 0), modifiers=('Alt',), button=0, type='mouse_press'
+        ),
+    )
+    qtbot.wait(10)
+    assert viewer._zoom_box.visible is False, (
+        'Zoom box should remain visible during drag'
+    )
+    assert viewer._zoom_box.canvas_positions == ((0, 0), (0, 0)), (
+        'Zoom box canvas positions should match the drag coordinates'
+    )

--- a/src/napari/_qt/layer_controls/qt_layer_controls_base.py
+++ b/src/napari/_qt/layer_controls/qt_layer_controls_base.py
@@ -100,6 +100,7 @@ class QtLayerControls(QFrame):
 
         # Buttons
         self.button_group = QButtonGroup(self)
+        # TODO:
         self.panzoom_button = self._radio_button(
             layer,
             'pan',
@@ -108,6 +109,7 @@ class QtLayerControls(QFrame):
             self.PAN_ZOOM_ACTION_NAME,
             extra_tooltip_text=trans._(
                 '\n(or hold Space)\n(hold Shift to pan in 3D)'
+                '\n(hold Alt to zoom via ROI selection)',
             ),
             checked=True,
         )

--- a/src/napari/_vispy/_tests/test_vispy_zoom_overlay.py
+++ b/src/napari/_vispy/_tests/test_vispy_zoom_overlay.py
@@ -1,0 +1,15 @@
+from napari._vispy.overlays.zoom import VispyZoomOverlay
+from napari.components.overlays import ZoomOverlay
+from napari.components.viewer_model import ViewerModel
+
+
+def test_zoom_overlay_initialization():
+    viewer = ViewerModel()
+    zoom_model = ZoomOverlay()
+    zoom_view = VispyZoomOverlay(viewer=viewer, overlay=zoom_model)
+
+    # change the visibility
+    assert zoom_view.node is not None
+    assert zoom_view.node.visible is False
+    zoom_model.visible = True
+    assert zoom_view.node.visible is True

--- a/src/napari/_vispy/overlays/base.py
+++ b/src/napari/_vispy/overlays/base.py
@@ -33,22 +33,22 @@ class VispyBaseOverlay:
         if parent is not None:
             self.node.parent = parent
 
-    def _on_visible_change(self):
+    def _on_visible_change(self) -> None:
         self.node.visible = self.overlay.visible
 
-    def _on_opacity_change(self):
+    def _on_opacity_change(self) -> None:
         self.node.opacity = self.overlay.opacity
 
-    def _on_blending_change(self):
+    def _on_blending_change(self) -> None:
         self.node.set_gl_state(**BLENDING_MODES[self.overlay.blending])
         self.node.update()
 
-    def reset(self):
+    def reset(self) -> None:
         self._on_visible_change()
         self._on_opacity_change()
         self._on_blending_change()
 
-    def close(self):
+    def close(self) -> None:
         disconnect_events(self.overlay.events, self)
         self.node.transforms = MatrixTransform()
         self.node.parent = None
@@ -124,7 +124,7 @@ class VispyCanvasOverlay(VispyBaseOverlay):
         scale = abs(self.node.transform.scale[0])
         self.node.transform.scale = [scale, 1, 1, 1]
 
-    def reset(self):
+    def reset(self) -> None:
         super().reset()
         self._on_position_change()
 
@@ -151,10 +151,10 @@ class LayerOverlayMixin:
         # always a child of the actual vispy node of the layer (eg, canvas overlays)
         self.layer.events.visible.connect(self._on_visible_change)
 
-    def _on_visible_change(self):
+    def _on_visible_change(self) -> None:
         self.node.visible = self.overlay.visible and self.layer.visible
 
-    def close(self):
+    def close(self) -> None:
         disconnect_events(self.layer.events, self)
         super().close()
 
@@ -168,6 +168,6 @@ class ViewerOverlayMixin:
         )
         self.viewer = viewer
 
-    def close(self):
+    def close(self) -> None:
         disconnect_events(self.viewer.events, self)
         super().close()

--- a/src/napari/_vispy/overlays/zoom.py
+++ b/src/napari/_vispy/overlays/zoom.py
@@ -1,0 +1,56 @@
+"""Vispy zoom box overlay."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
+
+from napari._vispy.overlays.base import ViewerOverlayMixin, VispyCanvasOverlay
+from napari._vispy.visuals.interaction_box import InteractionBox
+from napari.settings import get_settings
+
+if TYPE_CHECKING:
+    from napari.components.overlays import ZoomOverlay
+    from napari.components.viewer_model import ViewerModel
+    from napari.utils.events import Event
+
+
+class VispyZoomOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
+    """Zoom box overlay.."""
+
+    def __init__(
+        self,
+        viewer: ViewerModel,
+        overlay: ZoomOverlay,
+        parent: Optional[Any] = None,
+    ):
+        super().__init__(
+            node=InteractionBox(),
+            viewer=viewer,
+            overlay=overlay,
+            parent=parent,
+        )
+
+        self.overlay.events.canvas_positions.connect(self._on_positions_change)
+
+        self._on_visible_change()
+
+    def _on_positions_change(self, _evt: Optional[Event] = None) -> None:
+        """Change position."""
+        settings = get_settings()
+        self.node._highlight_width = (
+            settings.appearance.highlight.highlight_thickness
+        )
+        self.node._edge_color = settings.appearance.highlight.highlight_color
+
+        top_left, bot_right = self.overlay.canvas_positions
+        self.node.set_data(
+            # invert axes for vispy
+            top_left[::-1],
+            bot_right[::-1],
+            handles=False,
+            selected=None,
+        )
+
+    def reset(self) -> None:
+        """Reset the overlay."""
+        super().reset()

--- a/src/napari/_vispy/utils/visual.py
+++ b/src/napari/_vispy/utils/visual.py
@@ -24,6 +24,7 @@ from napari._vispy.overlays.interaction_box import (
 from napari._vispy.overlays.labels_polygon import VispyLabelsPolygonOverlay
 from napari._vispy.overlays.scale_bar import VispyScaleBarOverlay
 from napari._vispy.overlays.text import VispyTextOverlay
+from napari._vispy.overlays.zoom import VispyZoomOverlay
 from napari.components.overlays import (
     AxesOverlay,
     BoundingBoxOverlay,
@@ -34,6 +35,7 @@ from napari.components.overlays import (
     SelectionBoxOverlay,
     TextOverlay,
     TransformBoxOverlay,
+    ZoomOverlay,
 )
 from napari.layers import (
     Image,
@@ -67,6 +69,7 @@ overlay_to_visual: dict[type[Overlay], type[VispyBaseOverlay]] = {
     SelectionBoxOverlay: VispySelectionBoxOverlay,
     BrushCircleOverlay: VispyBrushCircleOverlay,
     LabelsPolygonOverlay: VispyLabelsPolygonOverlay,
+    ZoomOverlay: VispyZoomOverlay,
 }
 
 

--- a/src/napari/_vispy/visuals/interaction_box.py
+++ b/src/napari/_vispy/visuals/interaction_box.py
@@ -88,7 +88,12 @@ class InteractionBox(Compound):
         edges = edges if rotation else edges[:4]
         markers = self._marker_symbol if rotation else self._marker_symbol[:8]
 
-        self.line.set_data(pos=vertices, connect=edges)
+        self.line.set_data(
+            pos=vertices,
+            connect=edges,
+            color=self._edge_color,
+            width=self._highlight_width,
+        )
 
         if handles:
             marker_edges = np.zeros(len(vertices))

--- a/src/napari/components/_tests/test_zoom.py
+++ b/src/napari/components/_tests/test_zoom.py
@@ -1,0 +1,23 @@
+"""Zoom overlay."""
+
+import pytest
+
+from napari._pydantic_compat import ValidationError
+from napari.components.overlays.zoom import ZoomOverlay
+
+
+def test_zoom():
+    """Test creating zoom object"""
+    zoom = ZoomOverlay()
+    assert zoom is not None
+
+
+def test_zoom_values():
+    """Test creating zoom object"""
+    zoom = ZoomOverlay()
+    # validate canvas_positions
+    zoom.canvas_positions = ((0, 0), (300, 200))
+
+    # data_positions must be 2-D
+    with pytest.raises(ValidationError):
+        zoom.canvas_positions = ((0, 0, 0), (300, 200, 100))

--- a/src/napari/components/_viewer_mouse_bindings.py
+++ b/src/napari/components/_viewer_mouse_bindings.py
@@ -1,5 +1,9 @@
 import numpy as np
 
+# This is the minimum size of the zoom box (in pixels) that will
+# trigger a zoom when the user drags the mouse while holding Alt.
+MIN_ZOOMBOX_SIZE = 5
+
 
 def dims_scroll(viewer, event):
     """Scroll the dimensions slider."""
@@ -38,3 +42,50 @@ def double_click_to_zoom(viewer, event):
             np.asarray(event.position)[-2:]
             - np.asarray(viewer.camera.center)[-2:]
         ) * (1 - 1 / zoom_factor)
+
+
+def drag_to_zoom(viewer, event):
+    """While holding Alt, drag mouse to select a region to zoom.
+
+    This function allows the user to click and drag the mouse while
+    holding the `Alt` key to create a zoom box. When the mouse is released,
+    the camera zooms into the selected region.
+    """
+    if 'Alt' not in event.modifiers:
+        return
+
+    # on mouse press
+    press_pos, press_position = None, None
+    if event.type == 'mouse_press':
+        viewer._zoom_box.visible = True
+        press_pos = event.pos[::-1]
+        press_position = event.position
+        viewer._zoom_box.canvas_positions = (press_pos, press_pos)
+        yield
+        event.handled = True
+
+    # on mouse move
+    move_pos = press_pos
+    move_position = press_position
+    cancel = False
+    while event.type == 'mouse_move':
+        if press_pos is None:
+            continue
+        if 'Alt' in event.modifiers:
+            move_pos = event.pos[::-1]
+            viewer._zoom_box.canvas_positions = (press_pos, move_pos)
+            move_position = event.position
+        else:
+            # if Alt is released, cancel the zoom box
+            cancel = True
+            break
+        yield
+
+    # on mouse release
+    viewer._zoom_box.visible = False
+
+    # only trigger zoom if the box is larger than a MIN_ZOOMBOX_SIZE in pixels
+    distance = np.abs(np.array(press_pos) - np.array(move_pos))
+    if not cancel and distance.min() > MIN_ZOOMBOX_SIZE:
+        viewer._zoom_box.events.zoom(value=(press_position, move_position))
+    yield

--- a/src/napari/components/overlays/__init__.py
+++ b/src/napari/components/overlays/__init__.py
@@ -13,6 +13,7 @@ from napari.components.overlays.interaction_box import (
 from napari.components.overlays.labels_polygon import LabelsPolygonOverlay
 from napari.components.overlays.scale_bar import ScaleBarOverlay
 from napari.components.overlays.text import TextOverlay
+from napari.components.overlays.zoom import ZoomOverlay
 
 __all__ = [
     'AxesOverlay',
@@ -26,4 +27,5 @@ __all__ = [
     'SelectionBoxOverlay',
     'TextOverlay',
     'TransformBoxOverlay',
+    'ZoomOverlay',
 ]

--- a/src/napari/components/overlays/zoom.py
+++ b/src/napari/components/overlays/zoom.py
@@ -1,0 +1,43 @@
+"""Zoom-box."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from napari._pydantic_compat import validator
+from napari.components.overlays.base import CanvasOverlay
+from napari.utils.events import Event
+
+
+class ZoomOverlay(CanvasOverlay):
+    """A box that can be used to select and transform objects.
+
+    Attributes
+    ----------
+    canvas_positions : 2-tuple of 2-tuples
+        Corners at the top left and bottom right in canvas coordinates.
+    visible : bool
+        If the overlay is visible or not.
+    opacity : float
+        The opacity of the overlay. 0 is fully transparent.
+    order : int
+        The rendering order of the overlay: lower numbers get rendered first.
+    """
+
+    canvas_positions: tuple[tuple[float, float], tuple[float, float]] = (
+        (0, 0),
+        (0, 0),
+    )
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+        self.events.add(zoom=Event)
+
+    @validator('canvas_positions', pre=True, always=True, allow_reuse=True)
+    def _validate_bounds(
+        cls, v: tuple[tuple[float, ...], tuple[float, ...]]
+    ) -> tuple[tuple[float, float], tuple[float, float]]:
+        tup_1, tup_2 = v
+        x1, y1 = (float(coord) for coord in tup_1)
+        x2, y2 = (float(coord) for coord in tup_2)
+        return (x1, y1), (x2, y2)

--- a/src/napari/components/viewer_model.py
+++ b/src/napari/components/viewer_model.py
@@ -26,6 +26,7 @@ from napari.components._layer_slicer import _LayerSlicer
 from napari.components._viewer_mouse_bindings import (
     dims_scroll,
     double_click_to_zoom,
+    drag_to_zoom,
 )
 from napari.components.camera import Camera
 from napari.components.cursor import Cursor, CursorStyle
@@ -38,6 +39,7 @@ from napari.components.overlays import (
     Overlay,
     ScaleBarOverlay,
     TextOverlay,
+    ZoomOverlay,
 )
 from napari.components.tooltip import Tooltip
 from napari.errors import (
@@ -120,6 +122,7 @@ DEFAULT_OVERLAYS = {
     'text': TextOverlay,
     'axes': AxesOverlay,
     'brush_circle': BrushCircleOverlay,
+    'zoom': ZoomOverlay,
 }
 
 
@@ -287,6 +290,7 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         # Add mouse callback
         self.mouse_wheel_callbacks.append(dims_scroll)
         self.mouse_double_click_callbacks.append(double_click_to_zoom)
+        self.mouse_drag_callbacks.append(drag_to_zoom)
 
         self._overlays.update({k: v() for k, v in DEFAULT_OVERLAYS.items()})
 
@@ -302,6 +306,10 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
     @property
     def text_overlay(self):
         return self._overlays['text']
+
+    @property
+    def _zoom_box(self):
+        return self._overlays['zoom']
 
     @property
     def _brush_circle_overlay(self):
@@ -455,7 +463,9 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             angles=self.camera.angles,
         )
 
-    def _get_scene_parameters(self):
+    def _get_scene_parameters(
+        self,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Get the scene parameters for the current grid mode.
 
         Returns

--- a/src/napari/utils/misc.py
+++ b/src/napari/utils/misc.py
@@ -371,7 +371,9 @@ def all_subclasses(cls: type) -> set:
     )
 
 
-def ensure_n_tuple(val: Iterable, n: int, fill: int = 0) -> tuple:
+def ensure_n_tuple(
+    val: Iterable, n: int, fill: int = 0, before: bool = True
+) -> tuple:
     """Ensure input is a length n tuple.
 
     Parameters
@@ -380,6 +382,8 @@ def ensure_n_tuple(val: Iterable, n: int, fill: int = 0) -> tuple:
         Iterable to be forced into length n-tuple.
     n : int
         Length of tuple.
+    before : bool, default True
+        Fill the tuple with `fill` before or after the input iterable.
 
     Returns
     -------
@@ -388,7 +392,9 @@ def ensure_n_tuple(val: Iterable, n: int, fill: int = 0) -> tuple:
     """
     assert n > 0, 'n must be greater than 0'
     tuple_value = tuple(val)
-    return (fill,) * (n - len(tuple_value)) + tuple_value[-n:]
+    if before:
+        return (fill,) * (n - len(tuple_value)) + tuple_value[-n:]
+    return tuple_value[:n] + (fill,) * (n - len(tuple_value))
 
 
 def ensure_layer_data_tuple(val: tuple) -> tuple:


### PR DESCRIPTION
Recreated from original PR: https://github.com/napari/napari/pull/8004

# References and relevant issues

This PR adds an interactive zoom box to the viewer canvas. 
This closes the original issue #7630 

# Description

It's only active in 2-D view and all you need to do is hold Shift, press-down in the canvas, drag the mouse and release. Once released, a `zoom` event is emitted by the `ViewerModel` which is processed in the `canvas` class.

What's currently handled - things that need addressing by me:
- [x] add support for changing axes order
- [x] add con...